### PR TITLE
Support touchscreen movement to two pantilt presets #23

### DIFF
--- a/bin/touch-waypoint.py
+++ b/bin/touch-waypoint.py
@@ -1,0 +1,52 @@
+import struct
+import sys
+
+import requests
+from requests.auth import HTTPDigestAuth
+
+#
+# for now these are hardcoded
+#
+cam_host = "cam1"
+input_source = "event2"
+buffer_size = 60
+username = "admin"
+password = "password"
+
+#
+
+FORMAT = 'llhhI'
+EVENT_SIZE = struct.calcsize(FORMAT)
+
+infile = open('/dev/input/{}'.format(input_source), 'rb')
+url_template = "http://{}/cgi-bin/ptz.cgi?action=start&channel=1&code=GotoPreset&arg1=0&arg2={}&arg3=0"
+
+
+def is_abs(x): return x == 3
+
+
+def is_coord(x): return x == 0 or c == 1
+
+
+def is_y(x): return True if x else False
+
+
+def y_to_pre(x): return 0 if x < buffer_size else 1 if x > 480 - buffer_size else -1
+
+
+event = infile.read(EVENT_SIZE)
+while event:
+    (s, u, t, c, v) = struct.unpack(FORMAT, event)
+    if is_abs(t) and is_coord(c):
+        plane = "y" if c else "x"
+        print "click @ %s %d" % (plane, v)
+        if is_y(v):
+            preset = y_to_pre(v)
+            if preset > -1:
+                url = url_template.format(cam_host, preset)
+                print url
+                requests.get(url, auth=HTTPDigestAuth(username, password))
+
+    event = infile.read(EVENT_SIZE)
+
+infile.close()

--- a/etc/init.d/touch-waypoint
+++ b/etc/init.d/touch-waypoint
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+### BEGIN INIT INFO
+# Provides:          touch-waypoint.py
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+### END INIT INFO
+
+case "$1" in
+  start)
+    echo "Starting touch-waypoint.py"
+    /usr/local/bin/touch-waypoint.py &
+    ;;
+  stop)
+    echo "Stopping touch-waypoint.py"
+    pkill -f /usr/local/bin/touch-waypoint.py
+    ;;
+  *)
+    echo "Usage: /etc/init.d/touch-waypoint.sh {start|stop}"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -35,6 +35,7 @@ cp ${rootdir}/etc/init.d/* /etc/init.d
 update-rc.d isc-dhcp-server defaults
 update-rc.d camviewers defaults
 update-rc.d power-button defaults
+update-rc.d touch-waypoint defaults
 
 #
 # install cron jobs


### PR DESCRIPTION
Read touch events from python and for now just create a buffer on the left and right of screen.

When touch is detected call into the pan tilt api and move to preset 0 (left) or 1 (right).

Note: left and right is Y coordinates since we are flipped 270 degrees. 

